### PR TITLE
[bugfix] i2c总线频率为0

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -62,7 +62,7 @@ bool TwoWire::begin(int8_t sclPin, int8_t sdaPin, uint32_t frequency)
 
     _sclPin = sclPin;
     _sdaPin = sdaPin;
-    _clockFreq = frequency;
+    // _clockFreq = frequency;
 
     if((sclPin < 0) || (sdaPin < 0)) {
         LOG_E("Invaild sclPin(%d) or sdaPin(%d)\n", sclPin, sdaPin);


### PR DESCRIPTION
这行代码导致一些外部库在直接调用Wire.begin()不显性传入频率参数时，i2c总线频率为0，且Wire.setClock因此不起作用